### PR TITLE
ci: minimal, valid Deploy (Node 20, monorepo-safe)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,12 @@
 name: Deploy
-
 on:
-  push:
-    branches: [ main ]
+  push: { branches: [ main ] }
   workflow_dispatch:
-
+permissions:
+  contents: read
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -15,41 +17,25 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Setup Node (20.x)
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          check-latest: true
-          cache: npm
-          cache-dependency-path: apps/website/package-lock.json
-
-      - name: Show Node & npm
-        run: |
-          node -v
-          npm -v
-
-      - name: Install (husky-safe)
-        run: HUSKY=0 npm ci || HUSKY=0 npm install
-
-      # Non-blocking static checks (report warnings but don't fail deploy)
-      - name: Typecheck + Lint (soft)
-        run: |
-          npm run typecheck || true
-          npm run lint || true
-
+      - name: Install
+        run: HUSKY=0 npm ci
       - name: Build (Next.js)
         run: npm run build
-
       - name: Pull Vercel env (prod)
         run: npx vercel pull --yes --environment=production --token "$VERCEL_TOKEN"
-
       - name: Vercel build (prod)
         run: npx vercel build --prod --token "$VERCEL_TOKEN"
-
       - name: Vercel deploy (prebuilt, prod)
-        run: npx vercel deploy --prebuilt --prod --token "$VERCEL_TOKEN"
+        id: deploy
+        run: |
+          url=$(npx vercel deploy --prebuilt --prod --token "$VERCEL_TOKEN")
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+      - name: Output URL
+        run: echo "Deployed to ${{ steps.deploy.outputs.url }}"


### PR DESCRIPTION
Replace broken Deploy with a minimal, robust Node 20 workflow for apps/website. Keeps deploy focused on install→build→vercel. Secrets unchanged.