### PR TITLE
Deploy: stop failing on missing lockfile (remove cache-dependency-path)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,6 @@ jobs:
           node-version: 20.x
           check-latest: true
           cache: npm
-          cache-dependency-path: apps/website/package-lock.json
 
       - name: Show Node & npm
         run: |


### PR DESCRIPTION
actions/setup-node was failing because it referenced apps/website/package-lock.json which doesn't exist. Remove cache-dependency-path so the step doesn’t error and the deploy can proceed. No app files touched.