### PR TITLE
Deploy: stop failing on missing lockfile

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,6 @@ jobs:
           node-version: 20.x
           check-latest: true
           cache: npm
-          cache-dependency-path: apps/website/package-lock.json
 
       - name: Show Node & npm
         run: |


### PR DESCRIPTION
actions/setup-node fails when cache-dependency-path points to a non-existent lockfile. Remove that line so Deploy can proceed. No app files touched.