### PR TITLE
Use Vercel Git integration; disable GH Action autodeploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,7 @@
 name: Deploy
 
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
-
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Vercel is already connected to this repo and handles deploys on pushes to main. This change prevents duplicate/conflicting deploys.