### PR TITLE
M002.23: Bind ShopiFixer fix status to packet authority

### DIFF
--- a/src/app/fix-status/loading.tsx
+++ b/src/app/fix-status/loading.tsx
@@ -1,0 +1,30 @@
+import { getFixStatusCopy } from "@/lib/fixStatusPacketAuthority";
+import SystemProgressRail from "@/components/commerce/SystemProgressRail";
+import RuntimeContinuityStrip from "@/components/commerce/RuntimeContinuityStrip";
+
+export default function FixStatusLoading() {
+  const copy = getFixStatusCopy("LOADING");
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-5 py-8 text-slate-100 md:px-6 md:py-10">
+      <SystemProgressRail currentStage="approve" stateLabel={copy.label} className="px-0 pt-0" />
+      <RuntimeContinuityStrip
+        className="px-0"
+        items={[
+          { label: "Now", value: copy.label },
+          { label: "Next", value: "Wait for packet authority." },
+          { label: "Safe", value: "No status is shown before verification." },
+        ]}
+      />
+      <div className="mx-auto max-w-5xl">
+        <section className="rounded-[28px] border border-slate-800 bg-[linear-gradient(180deg,rgba(15,23,42,0.98),rgba(2,6,23,0.94))] p-6 shadow-xl shadow-black/25 md:p-8">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-cyan-300">Fix Status</p>
+          <h1 className="mt-3 max-w-3xl text-3xl font-semibold tracking-tight text-white md:text-4xl">
+            {copy.headline}
+          </h1>
+          <p className="mt-4 max-w-3xl text-base leading-8 text-slate-300">{copy.body}</p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/fix-status/loading.tsx
+++ b/src/app/fix-status/loading.tsx
@@ -12,7 +12,7 @@ export default function FixStatusLoading() {
         className="px-0"
         items={[
           { label: "Now", value: copy.label },
-          { label: "Next", value: "Wait for packet authority." },
+          { label: "Next", value: "Wait for status verification." },
           { label: "Safe", value: "No status is shown before verification." },
         ]}
       />

--- a/src/app/fix-status/page.tsx
+++ b/src/app/fix-status/page.tsx
@@ -38,7 +38,7 @@ export default async function FixStatusPage({ searchParams }: PageProps) {
   const packet = result.packet;
   const copy = getFixStatusCopy(result.state);
   const resolvedStore = packet ? cleanStoreDomain(packet.store_domain || packet.store_url || "") : "";
-  const proofAvailable = result.state === "PROOF_READY_OR_COMPLETED";
+  const proofAvailable = result.state === "PROOF_READY" || result.state === "COMPLETED";
   const canOpenNextStep = Boolean(packet && result.state !== "UNPAID" && result.state !== "STATUS_REVIEW");
   const primaryHref = proofAvailable
     ? buildContinuityHref("/fix-proof", result)
@@ -58,7 +58,7 @@ export default async function FixStatusPage({ searchParams }: PageProps) {
         items={[
           { label: "Now", value: copy.label },
           { label: "Next", value: merchantNextActionForResult(result) },
-          { label: "Safe", value: "Packet authority is checked first." },
+          { label: "Safe", value: "Status is verified first." },
         ]}
       />
       <div className="mx-auto max-w-5xl space-y-5 md:space-y-7">
@@ -88,7 +88,7 @@ export default async function FixStatusPage({ searchParams }: PageProps) {
               </p>
             </div>
             <div className="rounded-2xl border border-slate-800 bg-slate-950/45 p-4">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">Packet</p>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">Reference</p>
               <p className="mt-2 text-sm font-medium text-slate-100">
                 {displayPacketReference(packet)}
               </p>
@@ -96,7 +96,7 @@ export default async function FixStatusPage({ searchParams }: PageProps) {
           </div>
           {lastUpdated ? (
             <p className="mt-4 text-xs text-slate-500">
-              Last packet update: {lastUpdated}
+              Last status update: {lastUpdated}
             </p>
           ) : null}
         </section>
@@ -111,7 +111,7 @@ export default async function FixStatusPage({ searchParams }: PageProps) {
             <p className="mt-4 text-sm leading-7 text-slate-300">The review stays connected while the experience stays simple.</p>
             {!packet ? (
               <p className="mt-4 text-sm leading-7 text-slate-300">
-                This view does not show request progress until packet authority verifies the link.
+                This view does not show request progress until the link is verified.
               </p>
             ) : null}
           </div>

--- a/src/app/fix-status/page.tsx
+++ b/src/app/fix-status/page.tsx
@@ -1,7 +1,16 @@
 import Link from "next/link";
-import { lookupPacket, packetHref, type MinimumLifecycleState } from "@/lib/minimumStateContinuity";
 import SystemProgressRail from "@/components/commerce/SystemProgressRail";
 import RuntimeContinuityStrip from "@/components/commerce/RuntimeContinuityStrip";
+import {
+  buildContinuityHref,
+  cleanStoreDomain,
+  displayPacketReference,
+  getFixStatusCopy,
+  merchantNextActionForResult,
+  packetUpdatedAt,
+  publicProofLabel,
+  validateFixStatusRequest,
+} from "@/lib/fixStatusPacketAuthority";
 
 export const metadata = {
   title: "Fix Status - Stafford Media Consulting",
@@ -19,174 +28,27 @@ type PageProps = {
   }>;
 };
 
-function cleanStoreDomain(value: string) {
-  return String(value || "")
-    .trim()
-    .toLowerCase()
-    .replace(/^https?:\/\//, "")
-    .replace(/^www\./, "")
-    .replace(/\/.*$/, "");
-}
-
-function stateCopy(state: MinimumLifecycleState | "packet_missing") {
-  switch (state) {
-    case "payment_verified":
-    case "intake_pending":
-      return {
-        label: "Intake pending",
-        headline: "Your fix request is open.",
-        body: "Intake details come first.",
-      };
-    case "intake_started":
-      return {
-        label: "Intake open",
-        headline: "Your intake is open.",
-        body: "Store, access, approval contact, and audit context are confirmed before implementation work begins.",
-      };
-    case "awaiting_review":
-      return {
-        label: "Awaiting approval",
-        headline: "Your review is ready for approval.",
-        body: "You approve before anything launches.",
-      };
-    case "implementation_in_progress":
-      return {
-        label: "Controlled deployment",
-        headline: "Approved implementation work is active.",
-        body: "Visible updates remain approval-bound before completion.",
-      };
-    case "proof_ready":
-      return {
-        label: "Evidence ready",
-        headline: "Before-and-after review is ready.",
-        body: "Review the updated buying path before completion.",
-      };
-    case "unresolved":
-      return {
-        label: "Reviewing",
-        headline: "We’re reviewing the next step.",
-        body: "The next action needs confirmation.",
-      };
-    case "complete":
-      return {
-        label: "Complete",
-        headline: "Your storefront review is complete.",
-        body: "Confirm the work and any final notes.",
-      };
-    case "reverted":
-      return {
-        label: "Reviewing",
-        headline: "We’re reviewing the restored state.",
-        body: "The original storefront path stays accountable.",
-      };
-    default:
-      return {
-        label: "Request unavailable",
-        headline: "We need to link your request.",
-        body: "Use the payment or intake link tied to this store.",
-      };
-  }
-}
-
 function withStore(path: string, store: string) {
   return store ? `${path}?store=${encodeURIComponent(store)}` : path;
 }
 
-function publicProofLabel(value?: string) {
-  if (value === "ready" || value === "delivered") return "Proof ready";
-  if (value === "blocked") return "Review needed";
-  if (value === "not_started") return "Payment received";
-  return "Not available yet";
-}
-
-type PacketShape = {
-  packet_id?: string;
-  packetId?: string;
-  store_url?: string;
-  store_domain?: string;
-  reservation_id?: string;
-  reservationId?: string;
-  payment_reference?: string;
-  status?: string;
-  execution_status?: string;
-  proof_status?: string;
-  completion_status?: string;
-  current_lifecycle_state?: string;
-  lifecycle_state?: string;
-  currentLifecycleState?: string;
-  proof_state?: string;
-  proofState?: string;
-  proofStatus?: string;
-  merchant_next_action?: string;
-  merchantNextAction?: string;
-};
-
-function resolvePacketApiBase() {
-  const raw = String(process.env.NEXT_PUBLIC_SHOPIFIXER_CHECKOUT_API_BASE || process.env.NEXT_PUBLIC_ABANDO_URL || "https://pay.abando.ai").trim();
-  return raw.replace(/\/+$/, "");
-}
-
-async function fetchLivePacket(packetId: string): Promise<PacketShape | null> {
-  if (!packetId) return null;
-
-  try {
-    const response = await fetch(`${resolvePacketApiBase()}/api/packets/${encodeURIComponent(packetId)}`, {
-      cache: "no-store",
-      headers: {
-        Accept: "application/json",
-      },
-    });
-
-    if (!response.ok) return null;
-
-    const json = await response.json();
-    const packet = json?.packet || json;
-    return packet && typeof packet === "object" ? (packet as PacketShape) : null;
-  } catch {
-    return null;
-  }
-}
-
 export default async function FixStatusPage({ searchParams }: PageProps) {
   const params = (await searchParams) || {};
-  const packetId = String(params.packet_id || params.packet || "").trim();
-  const sessionId = String(params.session_id || "").trim();
-  const reservationId = String(params.reservation_id || "").trim();
-  const store = cleanStoreDomain(params.store || "");
-
-  const livePacket = packetId ? await fetchLivePacket(packetId) : null;
-  const fallbackPacketResult = livePacket ? null : await lookupPacket({ packetId, store });
-  const fallbackPacket = fallbackPacketResult?.status === "found" ? fallbackPacketResult.packet : null;
-  const packet = livePacket || fallbackPacket;
-  const packetData = packet as (PacketShape & { current_lifecycle_state?: MinimumLifecycleState; currentLifecycleState?: MinimumLifecycleState }) | null;
-  const resolvedStore = cleanStoreDomain(packetData?.store_url || packetData?.store_domain || store || "");
-  const resolvedReservationId = String(packetData?.reservation_id || packetData?.reservationId || reservationId || "").trim();
-  const resolvedPaymentReference = String(packetData?.payment_reference || sessionId || "").trim();
-  const packetForLinks = packetData
-    ? ({
-        packet_id: String(packetData.packet_id || packetData.packetId || packetId || ""),
-        store_url: resolvedStore || store,
-      } as {
-        packet_id: string;
-        store_url: string;
-      })
-    : null;
-  const normalizedProofStatus =
-    packetData?.proof_state ||
-    packetData?.proofState ||
-    packetData?.proof_status ||
-    packetData?.proofStatus ||
-    (packetData?.status === "payment_received" ? "not_started" : undefined);
-  const hasContinuityContext = Boolean(packetData || packetId || sessionId || resolvedReservationId || resolvedPaymentReference);
-  const state =
-    (packetData?.current_lifecycle_state ||
-      packetData?.currentLifecycleState ||
-      (packetData?.status === "payment_received" || hasContinuityContext ? "payment_verified" : "")) as MinimumLifecycleState | "" || "packet_missing";
-  const copy = stateCopy(state);
-  const hasContinuityState = state !== "packet_missing";
-  const proofAvailable =
-    normalizedProofStatus === "ready" ||
-    normalizedProofStatus === "delivered";
+  const result = await validateFixStatusRequest(params);
+  const packet = result.packet;
+  const copy = getFixStatusCopy(result.state);
+  const resolvedStore = packet ? cleanStoreDomain(packet.store_domain || packet.store_url || "") : "";
+  const proofAvailable = result.state === "PROOF_READY_OR_COMPLETED";
+  const canOpenNextStep = Boolean(packet && result.state !== "UNPAID" && result.state !== "STATUS_REVIEW");
+  const primaryHref = proofAvailable
+    ? buildContinuityHref("/fix-proof", result)
+    : canOpenNextStep
+      ? buildContinuityHref("/fix-review", result)
+      : resolvedStore
+        ? withStore("/pricing", resolvedStore)
+        : "/shopifixer";
+  const secondaryHref = packet ? buildContinuityHref("/fix-review", result) : "/shopifixer";
+  const lastUpdated = packetUpdatedAt(packet);
 
   return (
     <main className="min-h-screen bg-slate-950 px-5 py-8 text-slate-100 md:px-6 md:py-10">
@@ -194,9 +56,9 @@ export default async function FixStatusPage({ searchParams }: PageProps) {
       <RuntimeContinuityStrip
         className="px-0"
         items={[
-          { label: "Now", value: hasContinuityState ? copy.label : "Request unavailable." },
-          { label: "Next", value: "Open the next safe step." },
-          { label: "Safe", value: "You approve before launch." },
+          { label: "Now", value: copy.label },
+          { label: "Next", value: merchantNextActionForResult(result) },
+          { label: "Safe", value: "Packet authority is checked first." },
         ]}
       />
       <div className="mx-auto max-w-5xl space-y-5 md:space-y-7">
@@ -217,21 +79,26 @@ export default async function FixStatusPage({ searchParams }: PageProps) {
           <div className="mt-5 grid gap-3 md:grid-cols-3 md:gap-4">
             <div className="rounded-2xl border border-slate-800 bg-slate-950/45 p-4">
               <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">Store</p>
-              <p className="mt-2 text-sm font-medium text-slate-100">{resolvedStore || "Store confirmation required"}</p>
+              <p className="mt-2 text-sm font-medium text-slate-100">{resolvedStore || "Not verified"}</p>
             </div>
             <div className="rounded-2xl border border-slate-800 bg-slate-950/45 p-4">
               <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">Review</p>
               <p className="mt-2 text-sm font-medium text-slate-100">
-                {publicProofLabel(normalizedProofStatus)}
+                {publicProofLabel(packet)}
               </p>
             </div>
             <div className="rounded-2xl border border-slate-800 bg-slate-950/45 p-4">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">Next action</p>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">Packet</p>
               <p className="mt-2 text-sm font-medium text-slate-100">
-                {packet ? (packetData?.merchant_next_action || packetData?.merchantNextAction || "Open the next step.") : "Use the store-specific link."}
+                {displayPacketReference(packet)}
               </p>
             </div>
           </div>
+          {lastUpdated ? (
+            <p className="mt-4 text-xs text-slate-500">
+              Last packet update: {lastUpdated}
+            </p>
+          ) : null}
         </section>
 
         <details className="border-y border-slate-800/70 py-6">
@@ -242,9 +109,9 @@ export default async function FixStatusPage({ searchParams }: PageProps) {
           <div>
             <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-cyan-300">Review discipline</p>
             <p className="mt-4 text-sm leading-7 text-slate-300">The review stays connected while the experience stays simple.</p>
-            {!hasContinuityState ? (
+            {!packet ? (
               <p className="mt-4 text-sm leading-7 text-slate-300">
-                Your fix request is not linked to this view.
+                This view does not show request progress until packet authority verifies the link.
               </p>
             ) : null}
           </div>
@@ -259,27 +126,19 @@ export default async function FixStatusPage({ searchParams }: PageProps) {
 
         <section className="rounded-3xl border border-slate-800 bg-[linear-gradient(180deg,rgba(8,47,73,0.48),rgba(15,23,42,0.95))] p-5 shadow-lg shadow-black/10 md:p-6">
           <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-cyan-300">Continue</p>
-          <h2 className="mt-4 text-2xl font-semibold tracking-tight text-white">Open the next step.</h2>
+          <h2 className="mt-4 text-2xl font-semibold tracking-tight text-white">{merchantNextActionForResult(result)}</h2>
           <div className="mt-5 flex flex-wrap gap-3 md:gap-4">
             <Link
-              href={
-                proofAvailable
-                  ? packetForLinks
-                    ? packetHref("/fix-proof", packetForLinks as Parameters<typeof packetHref>[1])
-                    : withStore("/fix-proof", store)
-                  : packetForLinks
-                    ? packetHref("/fix-review", packetForLinks as Parameters<typeof packetHref>[1])
-                    : withStore("/fix-review", store)
-              }
+              href={primaryHref}
               className="rounded-full bg-cyan-400 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300"
             >
-              {proofAvailable ? "Open Proof Review" : "Return to Approval Review"}
+              {proofAvailable ? "Open Proof Review" : canOpenNextStep ? "Open Approval Review" : "Return to ShopiFixer"}
             </Link>
             <Link
-              href={packetForLinks ? packetHref("/fix-review", packetForLinks as Parameters<typeof packetHref>[1]) : withStore("/fix-review", store)}
+              href={secondaryHref}
               className="rounded-full border border-slate-600 px-5 py-3 text-sm font-semibold text-white transition hover:border-cyan-300 hover:text-cyan-200"
             >
-              Back to Fix Review
+              {packet ? "Back to Fix Review" : "Start Over"}
             </Link>
           </div>
         </section>

--- a/src/lib/fixStatusPacketAuthority.test.ts
+++ b/src/lib/fixStatusPacketAuthority.test.ts
@@ -3,7 +3,11 @@ import {
   FIX_STATUS_PACKET_API_BASE_ENV,
   getFixStatusCopy,
   mapPacketToMerchantState,
+  merchantNextActionForResult,
+  publicProofLabel,
+  displayPacketReference,
   validateFixStatusRequest,
+  type FixStatusMerchantState,
   type PacketAuthorityPacket,
 } from "./fixStatusPacketAuthority";
 
@@ -130,12 +134,27 @@ describe("validateFixStatusRequest", () => {
     expect(result.state).toBe("EXECUTION_PENDING");
   });
 
-  it("returns proof ready when proof or completion state proves availability", async () => {
+  it("returns proof ready when proof state proves availability", async () => {
     const result = await validateFixStatusRequest(params(), {
       env,
       fetchImpl: packetResponse({ ...basePacket, status: "payment_received", proof_status: "ready" }),
     });
-    expect(result.state).toBe("PROOF_READY_OR_COMPLETED");
+    expect(result.state).toBe("PROOF_READY");
+    expect(result.state).not.toBe("COMPLETED");
+  });
+
+  it("returns completed only when completion state proves completion", async () => {
+    const result = await validateFixStatusRequest(params(), {
+      env,
+      fetchImpl: packetResponse({
+        ...basePacket,
+        status: "payment_received",
+        proof_status: "ready",
+        completion_status: "complete",
+      }),
+    });
+    expect(result.state).toBe("COMPLETED");
+    expect(result.state).not.toBe("PROOF_READY");
   });
 
   it("renders unknown packet status as review instead of a positive request-open state", async () => {
@@ -176,5 +195,60 @@ describe("validateFixStatusRequest", () => {
 describe("mapPacketToMerchantState", () => {
   it("maps unsupported packet statuses to review", () => {
     expect(mapPacketToMerchantState({ ...basePacket, status: "unexpected" })).toBe("STATUS_REVIEW");
+  });
+
+  it("does not collapse proof-ready and completed lifecycle values", () => {
+    expect(mapPacketToMerchantState({ ...basePacket, status: "payment_received", proof_status: "ready" })).toBe("PROOF_READY");
+    expect(mapPacketToMerchantState({ ...basePacket, status: "payment_received", completion_status: "complete" })).toBe("COMPLETED");
+  });
+
+  it("gives completed requests a distinct supporting label", () => {
+    expect(publicProofLabel({ ...basePacket, proof_status: "ready" })).toBe("Proof ready");
+    expect(publicProofLabel({ ...basePacket, proof_status: "delivered", completion_status: "complete" })).toBe("Complete");
+  });
+});
+
+describe("merchant status copy", () => {
+  const states: FixStatusMerchantState[] = [
+    "LOADING",
+    "INVALID_REQUEST",
+    "NOT_FOUND_OR_MISMATCH",
+    "UNPAID",
+    "WEBHOOK_PENDING",
+    "PAID_OR_PAYMENT_RECEIVED",
+    "EXECUTION_PENDING",
+    "PROOF_READY",
+    "COMPLETED",
+    "SERVICE_UNAVAILABLE",
+    "STATUS_REVIEW",
+  ];
+
+  it("keeps status review merchant-safe", () => {
+    const copy = getFixStatusCopy("STATUS_REVIEW");
+    expect(`${copy.label} ${copy.headline} ${copy.body}`).not.toMatch(/operator|internal|deployment|packet|workflow|provider/i);
+  });
+
+  it("keeps all status copy and default actions free of operator terminology", () => {
+    const blockedTerms = /operator|internal|deployment|packet|workflow|provider|processing internally/i;
+    for (const state of states) {
+      const copy = getFixStatusCopy(state);
+      const action = merchantNextActionForResult({
+        state,
+        reason: "validated",
+        params: {
+          packetId: "packet_test_store_abc123",
+          sessionId: "cs_test_123",
+          store: "test-store.invalid",
+          reservationId: "res_123",
+        },
+        packet: state === "INVALID_REQUEST" || state === "NOT_FOUND_OR_MISMATCH" || state === "SERVICE_UNAVAILABLE" ? null : basePacket,
+      });
+
+      expect(`${copy.label} ${copy.headline} ${copy.body} ${action}`).not.toMatch(blockedTerms);
+    }
+  });
+
+  it("does not show the internal packet prefix in the public reference", () => {
+    expect(displayPacketReference(basePacket)).not.toMatch(/^packet/i);
   });
 });

--- a/src/lib/fixStatusPacketAuthority.test.ts
+++ b/src/lib/fixStatusPacketAuthority.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  FIX_STATUS_PACKET_API_BASE_ENV,
+  getFixStatusCopy,
+  mapPacketToMerchantState,
+  validateFixStatusRequest,
+  type PacketAuthorityPacket,
+} from "./fixStatusPacketAuthority";
+
+const env = {
+  [FIX_STATUS_PACKET_API_BASE_ENV]: "https://cart-agent-api-test.onrender.com",
+};
+
+const basePacket: PacketAuthorityPacket = {
+  packet_id: "packet_test_store_abc123",
+  store_domain: "test-store.invalid",
+  payment_reference: "cs_test_123",
+  reservation_id: "res_123",
+  status: "payment_pending",
+  execution_status: "not_started",
+  proof_status: "not_started",
+  completion_status: "not_started",
+  updated_at: "2026-07-24T19:00:00.000Z",
+};
+
+function params(overrides: Record<string, string> = {}) {
+  return {
+    packet_id: "packet_test_store_abc123",
+    session_id: "cs_test_123",
+    store: "test-store.invalid",
+    reservation_id: "res_123",
+    ...overrides,
+  };
+}
+
+function packetResponse(packet: PacketAuthorityPacket, status = 200) {
+  return vi.fn(async (url: string) => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => ({ ok: true, packet }),
+    url,
+  })) as unknown as typeof fetch;
+}
+
+function notFoundResponse() {
+  return vi.fn(async () => ({
+    ok: false,
+    status: 404,
+    json: async () => ({ ok: false, error: "packet_not_found" }),
+  })) as unknown as typeof fetch;
+}
+
+describe("validateFixStatusRequest", () => {
+  it("fails closed when packet_id is missing", async () => {
+    const result = await validateFixStatusRequest(params({ packet_id: "" }), { env, fetchImpl: packetResponse(basePacket) });
+    expect(result.state).toBe("INVALID_REQUEST");
+    expect(result.reason).toBe("missing_required_identifier");
+  });
+
+  it("fails closed when session_id is missing", async () => {
+    const result = await validateFixStatusRequest(params({ session_id: "" }), { env, fetchImpl: packetResponse(basePacket) });
+    expect(result.state).toBe("INVALID_REQUEST");
+  });
+
+  it("fails closed when store is missing", async () => {
+    const result = await validateFixStatusRequest(params({ store: "" }), { env, fetchImpl: packetResponse(basePacket) });
+    expect(result.state).toBe("INVALID_REQUEST");
+  });
+
+  it("returns not found for packet API 404", async () => {
+    const result = await validateFixStatusRequest(params(), { env, fetchImpl: notFoundResponse() });
+    expect(result.state).toBe("NOT_FOUND_OR_MISMATCH");
+    expect(result.reason).toBe("packet_not_found");
+  });
+
+  it("returns service unavailable on API network failure", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network failed");
+    }) as unknown as typeof fetch;
+    const result = await validateFixStatusRequest(params(), { env, fetchImpl });
+    expect(result.state).toBe("SERVICE_UNAVAILABLE");
+  });
+
+  it("rejects packet ID mismatch", async () => {
+    const result = await validateFixStatusRequest(params(), {
+      env,
+      fetchImpl: packetResponse({ ...basePacket, packet_id: "packet_other" }),
+    });
+    expect(result.state).toBe("NOT_FOUND_OR_MISMATCH");
+    expect(result.reason).toBe("packet_id_mismatch");
+  });
+
+  it("rejects session ID mismatch", async () => {
+    const result = await validateFixStatusRequest(params(), {
+      env,
+      fetchImpl: packetResponse({ ...basePacket, payment_reference: "cs_test_other" }),
+    });
+    expect(result.state).toBe("NOT_FOUND_OR_MISMATCH");
+    expect(result.reason).toBe("session_id_mismatch");
+  });
+
+  it("rejects store mismatch", async () => {
+    const result = await validateFixStatusRequest(params(), {
+      env,
+      fetchImpl: packetResponse({ ...basePacket, store_domain: "other-store.invalid" }),
+    });
+    expect(result.state).toBe("NOT_FOUND_OR_MISMATCH");
+    expect(result.reason).toBe("store_mismatch");
+  });
+
+  it("returns unpaid for a valid payment_pending packet", async () => {
+    const result = await validateFixStatusRequest(params(), { env, fetchImpl: packetResponse(basePacket) });
+    expect(result.state).toBe("UNPAID");
+    expect(result.packet?.packet_id).toBe(basePacket.packet_id);
+  });
+
+  it("returns payment received for a valid paid packet with active execution", async () => {
+    const result = await validateFixStatusRequest(params(), {
+      env,
+      fetchImpl: packetResponse({ ...basePacket, status: "payment_received", execution_status: "in_progress" }),
+    });
+    expect(result.state).toBe("PAID_OR_PAYMENT_RECEIVED");
+  });
+
+  it("returns execution pending for a valid paid packet without execution", async () => {
+    const result = await validateFixStatusRequest(params(), {
+      env,
+      fetchImpl: packetResponse({ ...basePacket, status: "payment_received", execution_status: "not_started" }),
+    });
+    expect(result.state).toBe("EXECUTION_PENDING");
+  });
+
+  it("returns proof ready when proof or completion state proves availability", async () => {
+    const result = await validateFixStatusRequest(params(), {
+      env,
+      fetchImpl: packetResponse({ ...basePacket, status: "payment_received", proof_status: "ready" }),
+    });
+    expect(result.state).toBe("PROOF_READY_OR_COMPLETED");
+  });
+
+  it("renders unknown packet status as review instead of a positive request-open state", async () => {
+    const result = await validateFixStatusRequest(params(), {
+      env,
+      fetchImpl: packetResponse({ ...basePacket, status: "mystery_state" }),
+    });
+    expect(result.state).toBe("STATUS_REVIEW");
+    expect(getFixStatusCopy(result.state).headline).not.toMatch(/request is open/i);
+  });
+
+  it("uses the explicit test API origin", async () => {
+    const fetchImpl = packetResponse(basePacket);
+    await validateFixStatusRequest(params(), { env, fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://cart-agent-api-test.onrender.com/api/packets/packet_test_store_abc123",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+  });
+
+  it("does not fall back to production when API origin is absent", async () => {
+    const fetchImpl = packetResponse(basePacket);
+    const result = await validateFixStatusRequest(params(), { env: {}, fetchImpl });
+    expect(result.state).toBe("SERVICE_UNAVAILABLE");
+    expect(result.reason).toBe("missing_api_origin");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("never calls an operator endpoint", async () => {
+    const fetchImpl = packetResponse(basePacket);
+    await validateFixStatusRequest(params(), { env, fetchImpl });
+    const calledUrl = String(vi.mocked(fetchImpl).mock.calls[0]?.[0] || "");
+    expect(calledUrl).toContain("/api/packets/");
+    expect(calledUrl).not.toContain("/api/operator/");
+  });
+});
+
+describe("mapPacketToMerchantState", () => {
+  it("maps unsupported packet statuses to review", () => {
+    expect(mapPacketToMerchantState({ ...basePacket, status: "unexpected" })).toBe("STATUS_REVIEW");
+  });
+});

--- a/src/lib/fixStatusPacketAuthority.ts
+++ b/src/lib/fixStatusPacketAuthority.ts
@@ -1,0 +1,452 @@
+export const FIX_STATUS_PACKET_API_BASE_ENV = "NEXT_PUBLIC_SHOPIFIXER_CHECKOUT_API_BASE";
+
+export type FixStatusMerchantState =
+  | "LOADING"
+  | "INVALID_REQUEST"
+  | "NOT_FOUND_OR_MISMATCH"
+  | "UNPAID"
+  | "WEBHOOK_PENDING"
+  | "PAID_OR_PAYMENT_RECEIVED"
+  | "EXECUTION_PENDING"
+  | "PROOF_READY_OR_COMPLETED"
+  | "SERVICE_UNAVAILABLE"
+  | "STATUS_REVIEW";
+
+export type FixStatusQuery = {
+  packet?: string;
+  packet_id?: string;
+  session_id?: string;
+  store?: string;
+  reservation_id?: string;
+};
+
+export type PacketAuthorityPacket = {
+  packet_id?: string;
+  packetId?: string;
+  store_domain?: string;
+  store_url?: string;
+  reservation_id?: string | null;
+  reservationId?: string | null;
+  payment_reference?: string | null;
+  paymentReference?: string | null;
+  status?: string | null;
+  execution_status?: string | null;
+  executionStatus?: string | null;
+  proof_status?: string | null;
+  proofStatus?: string | null;
+  completion_status?: string | null;
+  completionStatus?: string | null;
+  created_at?: string | null;
+  createdAt?: string | null;
+  updated_at?: string | null;
+  updatedAt?: string | null;
+  merchant_next_action?: string | null;
+  merchantNextAction?: string | null;
+};
+
+export type FixStatusValidationResult = {
+  state: FixStatusMerchantState;
+  reason:
+    | "missing_required_identifier"
+    | "malformed_identifier"
+    | "missing_api_origin"
+    | "invalid_api_origin"
+    | "packet_not_found"
+    | "api_unavailable"
+    | "invalid_api_payload"
+    | "packet_id_mismatch"
+    | "session_id_mismatch"
+    | "store_mismatch"
+    | "reservation_id_mismatch"
+    | "validated";
+  params: {
+    packetId: string;
+    sessionId: string;
+    store: string;
+    reservationId: string;
+  };
+  apiBase?: string;
+  packet: PacketAuthorityPacket | null;
+};
+
+type FetchLike = typeof fetch;
+
+const identifierPattern = /^[A-Za-z0-9_.:-]+$/;
+const storePattern = /^[a-z0-9.-]+$/;
+
+export function cleanStoreDomain(value: string) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, "")
+    .replace(/^www\./, "")
+    .split("/")[0]
+    .split("?")[0]
+    .split("#")[0];
+}
+
+function normalizeIdentifier(value: unknown) {
+  return String(value ?? "").trim();
+}
+
+function normalizePacketId(packet: PacketAuthorityPacket) {
+  return normalizeIdentifier(packet.packet_id || packet.packetId);
+}
+
+function normalizePaymentReference(packet: PacketAuthorityPacket) {
+  return normalizeIdentifier(packet.payment_reference || packet.paymentReference);
+}
+
+function normalizeReservationId(packet: PacketAuthorityPacket) {
+  return normalizeIdentifier(packet.reservation_id || packet.reservationId);
+}
+
+function normalizePacketStore(packet: PacketAuthorityPacket) {
+  return cleanStoreDomain(String(packet.store_domain || packet.store_url || ""));
+}
+
+function normalizeStatus(value: unknown) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function isSafeIdentifier(value: string) {
+  return Boolean(value && identifierPattern.test(value));
+}
+
+function isSafeStore(value: string) {
+  return Boolean(value && storePattern.test(value));
+}
+
+function resolvePacketApiBase(env: NodeJS.ProcessEnv = process.env) {
+  const raw = String(env[FIX_STATUS_PACKET_API_BASE_ENV] || "").trim();
+  if (!raw) {
+    return { ok: false as const, reason: "missing_api_origin" as const };
+  }
+
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      return { ok: false as const, reason: "invalid_api_origin" as const };
+    }
+
+    return {
+      ok: true as const,
+      apiBase: url.toString().replace(/\/+$/, ""),
+    };
+  } catch {
+    return { ok: false as const, reason: "invalid_api_origin" as const };
+  }
+}
+
+export function normalizeFixStatusQuery(params: FixStatusQuery = {}) {
+  return {
+    packetId: normalizeIdentifier(params.packet_id || params.packet),
+    sessionId: normalizeIdentifier(params.session_id),
+    store: cleanStoreDomain(params.store || ""),
+    reservationId: normalizeIdentifier(params.reservation_id),
+  };
+}
+
+export function mapPacketToMerchantState(packet: PacketAuthorityPacket): FixStatusMerchantState {
+  const status = normalizeStatus(packet.status);
+  const executionStatus = normalizeStatus(packet.execution_status || packet.executionStatus);
+  const proofStatus = normalizeStatus(packet.proof_status || packet.proofStatus);
+  const completionStatus = normalizeStatus(packet.completion_status || packet.completionStatus);
+
+  if (proofStatus === "ready" || proofStatus === "delivered" || completionStatus === "complete") {
+    return "PROOF_READY_OR_COMPLETED";
+  }
+
+  if (status === "payment_received" || status === "paid") {
+    if (!executionStatus || executionStatus === "not_started" || executionStatus === "pending") {
+      return "EXECUTION_PENDING";
+    }
+
+    return "PAID_OR_PAYMENT_RECEIVED";
+  }
+
+  if (status === "payment_pending" || status === "prepared") {
+    return "UNPAID";
+  }
+
+  return "STATUS_REVIEW";
+}
+
+export async function validateFixStatusRequest(
+  params: FixStatusQuery,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    fetchImpl?: FetchLike;
+  } = {},
+): Promise<FixStatusValidationResult> {
+  const normalized = normalizeFixStatusQuery(params);
+  const fetchImpl = options.fetchImpl || fetch;
+
+  const baseResult = {
+    params: normalized,
+    packet: null,
+  };
+
+  if (!normalized.packetId || !normalized.sessionId || !normalized.store) {
+    return {
+      ...baseResult,
+      state: "INVALID_REQUEST",
+      reason: "missing_required_identifier",
+    };
+  }
+
+  if (
+    !isSafeIdentifier(normalized.packetId) ||
+    !isSafeIdentifier(normalized.sessionId) ||
+    !isSafeStore(normalized.store) ||
+    (normalized.reservationId && !isSafeIdentifier(normalized.reservationId))
+  ) {
+    return {
+      ...baseResult,
+      state: "INVALID_REQUEST",
+      reason: "malformed_identifier",
+    };
+  }
+
+  const apiBase = resolvePacketApiBase(options.env);
+  if (!apiBase.ok) {
+    return {
+      ...baseResult,
+      state: "SERVICE_UNAVAILABLE",
+      reason: apiBase.reason,
+    };
+  }
+
+  try {
+    const response = await fetchImpl(`${apiBase.apiBase}/api/packets/${encodeURIComponent(normalized.packetId)}`, {
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+
+    if (response.status === 404) {
+      return {
+        ...baseResult,
+        apiBase: apiBase.apiBase,
+        state: "NOT_FOUND_OR_MISMATCH",
+        reason: "packet_not_found",
+      };
+    }
+
+    if (!response.ok) {
+      return {
+        ...baseResult,
+        apiBase: apiBase.apiBase,
+        state: "SERVICE_UNAVAILABLE",
+        reason: "api_unavailable",
+      };
+    }
+
+    const json = await response.json();
+    const packet = json?.packet;
+
+    if (!packet || typeof packet !== "object" || Array.isArray(packet)) {
+      return {
+        ...baseResult,
+        apiBase: apiBase.apiBase,
+        state: "NOT_FOUND_OR_MISMATCH",
+        reason: "invalid_api_payload",
+      };
+    }
+
+    const typedPacket = packet as PacketAuthorityPacket;
+    const packetId = normalizePacketId(typedPacket);
+    const paymentReference = normalizePaymentReference(typedPacket);
+    const packetStore = normalizePacketStore(typedPacket);
+    const storedReservationId = normalizeReservationId(typedPacket);
+
+    if (packetId !== normalized.packetId) {
+      return {
+        ...baseResult,
+        apiBase: apiBase.apiBase,
+        packet: typedPacket,
+        state: "NOT_FOUND_OR_MISMATCH",
+        reason: "packet_id_mismatch",
+      };
+    }
+
+    if (paymentReference !== normalized.sessionId) {
+      return {
+        ...baseResult,
+        apiBase: apiBase.apiBase,
+        packet: typedPacket,
+        state: "NOT_FOUND_OR_MISMATCH",
+        reason: "session_id_mismatch",
+      };
+    }
+
+    if (packetStore !== normalized.store) {
+      return {
+        ...baseResult,
+        apiBase: apiBase.apiBase,
+        packet: typedPacket,
+        state: "NOT_FOUND_OR_MISMATCH",
+        reason: "store_mismatch",
+      };
+    }
+
+    if (normalized.reservationId && storedReservationId && storedReservationId !== normalized.reservationId) {
+      return {
+        ...baseResult,
+        apiBase: apiBase.apiBase,
+        packet: typedPacket,
+        state: "NOT_FOUND_OR_MISMATCH",
+        reason: "reservation_id_mismatch",
+      };
+    }
+
+    return {
+      ...baseResult,
+      apiBase: apiBase.apiBase,
+      packet: typedPacket,
+      state: mapPacketToMerchantState(typedPacket),
+      reason: "validated",
+    };
+  } catch {
+    return {
+      ...baseResult,
+      apiBase: apiBase.apiBase,
+      state: "SERVICE_UNAVAILABLE",
+      reason: "api_unavailable",
+    };
+  }
+}
+
+export function getFixStatusCopy(state: FixStatusMerchantState) {
+  switch (state) {
+    case "LOADING":
+      return {
+        label: "Checking status",
+        headline: "Checking your fix request.",
+        body: "Packet authority is being checked before any status is shown.",
+      };
+    case "INVALID_REQUEST":
+      return {
+        label: "Link required",
+        headline: "We need a valid status link.",
+        body: "Use the payment return link tied to this store.",
+      };
+    case "NOT_FOUND_OR_MISMATCH":
+      return {
+        label: "Request not verified",
+        headline: "We could not verify this fix request.",
+        body: "This link does not match an active ShopiFixer packet.",
+      };
+    case "SERVICE_UNAVAILABLE":
+      return {
+        label: "Status unavailable",
+        headline: "Status is temporarily unavailable.",
+        body: "Packet authority could not be reached. Try the same link again shortly.",
+      };
+    case "UNPAID":
+      return {
+        label: "Payment pending",
+        headline: "Payment has not been confirmed yet.",
+        body: "Your request is reserved, but work starts only after payment is verified.",
+      };
+    case "WEBHOOK_PENDING":
+      return {
+        label: "Verification pending",
+        headline: "Payment verification is still catching up.",
+        body: "Keep this page open while packet authority receives the payment confirmation.",
+      };
+    case "EXECUTION_PENDING":
+      return {
+        label: "Payment received",
+        headline: "Payment is confirmed. Your fix is queued.",
+        body: "The packet is ready for the next controlled execution step.",
+      };
+    case "PAID_OR_PAYMENT_RECEIVED":
+      return {
+        label: "Payment received",
+        headline: "Your fix request is verified.",
+        body: "Your ShopiFixer packet is connected and ready for the next governed step.",
+      };
+    case "PROOF_READY_OR_COMPLETED":
+      return {
+        label: "Proof ready",
+        headline: "Before-and-after review is ready.",
+        body: "Review the visible proof tied to this packet.",
+      };
+    default:
+      return {
+        label: "Reviewing status",
+        headline: "We are reviewing this status.",
+        body: "Packet authority returned a state that needs operator review before we show the next step.",
+      };
+  }
+}
+
+export function publicProofLabel(packet: PacketAuthorityPacket | null) {
+  if (!packet) return "Not available";
+
+  const proofStatus = normalizeStatus(packet.proof_status || packet.proofStatus);
+  const completionStatus = normalizeStatus(packet.completion_status || packet.completionStatus);
+  const status = normalizeStatus(packet.status);
+
+  if (proofStatus === "ready" || proofStatus === "delivered" || completionStatus === "complete") {
+    return "Proof ready";
+  }
+
+  if (status === "payment_received" || status === "paid") {
+    return "Payment received";
+  }
+
+  if (status === "payment_pending" || status === "prepared") {
+    return "Payment pending";
+  }
+
+  return "Under review";
+}
+
+export function displayPacketReference(packet: PacketAuthorityPacket | null) {
+  const packetId = packet ? normalizePacketId(packet) : "";
+  if (!packetId) return "Not verified";
+  if (packetId.length <= 18) return packetId;
+  return `${packetId.slice(0, 10)}...${packetId.slice(-6)}`;
+}
+
+export function packetUpdatedAt(packet: PacketAuthorityPacket | null) {
+  return normalizeIdentifier(packet?.updated_at || packet?.updatedAt || packet?.created_at || packet?.createdAt);
+}
+
+export function merchantNextActionForResult(result: FixStatusValidationResult) {
+  if (result.packet?.merchant_next_action || result.packet?.merchantNextAction) {
+    return String(result.packet.merchant_next_action || result.packet.merchantNextAction);
+  }
+
+  switch (result.state) {
+    case "UNPAID":
+      return "Return to checkout if payment was not completed.";
+    case "EXECUTION_PENDING":
+    case "PAID_OR_PAYMENT_RECEIVED":
+      return "Watch for the next governed fix update.";
+    case "PROOF_READY_OR_COMPLETED":
+      return "Open the proof review for this packet.";
+    case "SERVICE_UNAVAILABLE":
+      return "Use the same link again after status reconnects.";
+    default:
+      return "Use the verified payment return link for this store.";
+  }
+}
+
+export function buildContinuityHref(pathname: string, result: FixStatusValidationResult) {
+  if (!result.packet) return pathname;
+
+  const query = new URLSearchParams();
+  query.set("store", normalizePacketStore(result.packet));
+  query.set("packet", normalizePacketId(result.packet));
+  query.set("packet_id", normalizePacketId(result.packet));
+  query.set("session_id", normalizePaymentReference(result.packet));
+
+  const reservationId = normalizeReservationId(result.packet);
+  if (reservationId) query.set("reservation_id", reservationId);
+
+  return `${pathname}?${query.toString()}`;
+}

--- a/src/lib/fixStatusPacketAuthority.ts
+++ b/src/lib/fixStatusPacketAuthority.ts
@@ -8,7 +8,8 @@ export type FixStatusMerchantState =
   | "WEBHOOK_PENDING"
   | "PAID_OR_PAYMENT_RECEIVED"
   | "EXECUTION_PENDING"
-  | "PROOF_READY_OR_COMPLETED"
+  | "PROOF_READY"
+  | "COMPLETED"
   | "SERVICE_UNAVAILABLE"
   | "STATUS_REVIEW";
 
@@ -153,8 +154,12 @@ export function mapPacketToMerchantState(packet: PacketAuthorityPacket): FixStat
   const proofStatus = normalizeStatus(packet.proof_status || packet.proofStatus);
   const completionStatus = normalizeStatus(packet.completion_status || packet.completionStatus);
 
-  if (proofStatus === "ready" || proofStatus === "delivered" || completionStatus === "complete") {
-    return "PROOF_READY_OR_COMPLETED";
+  if (completionStatus === "complete") {
+    return "COMPLETED";
+  }
+
+  if (proofStatus === "ready" || proofStatus === "delivered") {
+    return "PROOF_READY";
   }
 
   if (status === "payment_received" || status === "paid") {
@@ -324,7 +329,7 @@ export function getFixStatusCopy(state: FixStatusMerchantState) {
       return {
         label: "Checking status",
         headline: "Checking your fix request.",
-        body: "Packet authority is being checked before any status is shown.",
+        body: "Your secure status link is being checked before any progress is shown.",
       };
     case "INVALID_REQUEST":
       return {
@@ -336,13 +341,13 @@ export function getFixStatusCopy(state: FixStatusMerchantState) {
       return {
         label: "Request not verified",
         headline: "We could not verify this fix request.",
-        body: "This link does not match an active ShopiFixer packet.",
+        body: "This link does not match an active ShopiFixer request.",
       };
     case "SERVICE_UNAVAILABLE":
       return {
         label: "Status unavailable",
         headline: "Status is temporarily unavailable.",
-        body: "Packet authority could not be reached. Try the same link again shortly.",
+        body: "The status source could not be reached. Try the same link again shortly.",
       };
     case "UNPAID":
       return {
@@ -354,31 +359,37 @@ export function getFixStatusCopy(state: FixStatusMerchantState) {
       return {
         label: "Verification pending",
         headline: "Payment verification is still catching up.",
-        body: "Keep this page open while packet authority receives the payment confirmation.",
+        body: "Keep this page open while payment confirmation is recorded.",
       };
     case "EXECUTION_PENDING":
       return {
         label: "Payment received",
         headline: "Payment is confirmed. Your fix is queued.",
-        body: "The packet is ready for the next controlled execution step.",
+        body: "Your request is ready for the next fix step.",
       };
     case "PAID_OR_PAYMENT_RECEIVED":
       return {
         label: "Payment received",
         headline: "Your fix request is verified.",
-        body: "Your ShopiFixer packet is connected and ready for the next governed step.",
+        body: "Your ShopiFixer request is connected and ready for the next update.",
       };
-    case "PROOF_READY_OR_COMPLETED":
+    case "PROOF_READY":
       return {
         label: "Proof ready",
         headline: "Before-and-after review is ready.",
-        body: "Review the visible proof tied to this packet.",
+        body: "Review the visible before-and-after proof for this request.",
+      };
+    case "COMPLETED":
+      return {
+        label: "Work complete",
+        headline: "Your requested fix is complete.",
+        body: "The completed work and proof are ready for review.",
       };
     default:
       return {
         label: "Reviewing status",
         headline: "We are reviewing this status.",
-        body: "Packet authority returned a state that needs operator review before we show the next step.",
+        body: "We need another status check before showing the next step.",
       };
   }
 }
@@ -390,7 +401,11 @@ export function publicProofLabel(packet: PacketAuthorityPacket | null) {
   const completionStatus = normalizeStatus(packet.completion_status || packet.completionStatus);
   const status = normalizeStatus(packet.status);
 
-  if (proofStatus === "ready" || proofStatus === "delivered" || completionStatus === "complete") {
+  if (completionStatus === "complete") {
+    return "Complete";
+  }
+
+  if (proofStatus === "ready" || proofStatus === "delivered") {
     return "Proof ready";
   }
 
@@ -408,8 +423,9 @@ export function publicProofLabel(packet: PacketAuthorityPacket | null) {
 export function displayPacketReference(packet: PacketAuthorityPacket | null) {
   const packetId = packet ? normalizePacketId(packet) : "";
   if (!packetId) return "Not verified";
-  if (packetId.length <= 18) return packetId;
-  return `${packetId.slice(0, 10)}...${packetId.slice(-6)}`;
+  const publicReference = packetId.replace(/^packet[_:-]?/i, "");
+  if (publicReference.length <= 18) return publicReference;
+  return `${publicReference.slice(0, 10)}...${publicReference.slice(-6)}`;
 }
 
 export function packetUpdatedAt(packet: PacketAuthorityPacket | null) {
@@ -426,9 +442,11 @@ export function merchantNextActionForResult(result: FixStatusValidationResult) {
       return "Return to checkout if payment was not completed.";
     case "EXECUTION_PENDING":
     case "PAID_OR_PAYMENT_RECEIVED":
-      return "Watch for the next governed fix update.";
-    case "PROOF_READY_OR_COMPLETED":
-      return "Open the proof review for this packet.";
+      return "Watch for your next fix update.";
+    case "PROOF_READY":
+      return "Open your proof review.";
+    case "COMPLETED":
+      return "Review your completed fix.";
     case "SERVICE_UNAVAILABLE":
       return "Use the same link again after status reconnects.";
     default:


### PR DESCRIPTION
Mission:
M002.23_STAFFORDMEDIA_FIX_STATUS_PACKET_AUTHORITY_BINDING

Scope:
- binds /fix-status to GET /api/packets/:packetId
- requires packet_id, session_id, and store
- fails closed for missing, bogus, or mismatched authority
- does not call operator APIs
- does not change checkout, Stripe, packets, StaffordOS, or production runtime

Implementation commit:
7d97e4dcc6b9e81bd1ba2881fdc9228f23b54829

Validation:
- focused Vitest suite passed
- lint passed
- production build passed
- existing homepage E2E selector failures reproduced on clean baseline

This PR exists only for isolated Render preview certification.
Do not merge until a later explicitly authorized mission.