### PR TITLE
M004.01: Fail closed without checkout authority

### DIFF
--- a/src/app/pricing/PacketCheckoutButton.test.tsx
+++ b/src/app/pricing/PacketCheckoutButton.test.tsx
@@ -1,0 +1,144 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import PacketCheckoutButton, { resolveCheckoutApiOrigin } from "./PacketCheckoutButton";
+
+globalThis.React = React;
+
+const checkoutUnavailableMessage = /checkout is temporarily unavailable\. please try again later\./i;
+const validOrigin = "https://cart-agent-api.onrender.com";
+
+function setCheckoutOrigin(value: string | undefined) {
+  if (value === undefined) {
+    delete process.env.NEXT_PUBLIC_SHOPIFIXER_CHECKOUT_API_BASE;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_SHOPIFIXER_CHECKOUT_API_BASE = value;
+}
+
+function mockFailedCheckoutFetch() {
+  const fetchMock = vi.fn(async () => ({
+    ok: false,
+    status: 503,
+    json: async () => ({ message: "backend detail should stay hidden" }),
+  })) as unknown as typeof fetch;
+
+  vi.stubGlobal("fetch", fetchMock);
+  return vi.mocked(fetchMock);
+}
+
+async function clickCheckout() {
+  fireEvent.click(screen.getByRole("button", { name: /start my fix/i }));
+  await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+}
+
+describe("resolveCheckoutApiOrigin", () => {
+  it("accepts an explicit HTTPS checkout origin", () => {
+    expect(resolveCheckoutApiOrigin(validOrigin)).toBe(validOrigin);
+  });
+
+  it("normalizes a trailing slash", () => {
+    expect(resolveCheckoutApiOrigin(`${validOrigin}/`)).toBe(validOrigin);
+  });
+
+  it("normalizes surrounding whitespace", () => {
+    expect(resolveCheckoutApiOrigin(`  ${validOrigin}  `)).toBe(validOrigin);
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+    ["malformed", "not a url"],
+    ["http", "http://cart-agent-api.onrender.com"],
+    ["credentials", "https://user:pass@cart-agent-api.onrender.com"],
+    ["query", "https://cart-agent-api.onrender.com?fallback=1"],
+    ["fragment", "https://cart-agent-api.onrender.com#checkout"],
+  ])("rejects %s checkout authority", (_caseName, value) => {
+    expect(resolveCheckoutApiOrigin(value)).toBeNull();
+  });
+
+  it("does not contain the historical checkout origin in the pricing implementation", () => {
+    const source = readFileSync("src/app/pricing/PacketCheckoutButton.tsx", "utf8");
+    const historicalOrigin = ["pay", "abando", "ai"].join(".");
+    expect(source).not.toContain(historicalOrigin);
+  });
+});
+
+describe("PacketCheckoutButton", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    setCheckoutOrigin(undefined);
+  });
+
+  it("posts to the configured checkout origin with the expected method and payload", async () => {
+    setCheckoutOrigin(validOrigin);
+    const fetchMock = mockFailedCheckoutFetch();
+
+    render(<PacketCheckoutButton storeDomain="test-store.invalid" />);
+    await clickCheckout();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${validOrigin}/__public-checkout`,
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ plan: "scale", store_domain: "test-store.invalid" }),
+      }),
+    );
+  });
+
+  it("uses one slash before the checkout path when the configured origin has a trailing slash", async () => {
+    setCheckoutOrigin(`${validOrigin}/`);
+    const fetchMock = mockFailedCheckoutFetch();
+
+    render(<PacketCheckoutButton storeDomain="test-store.invalid" />);
+    await clickCheckout();
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(`${validOrigin}/__public-checkout`);
+  });
+
+  it("uses the normalized origin when the configured value has surrounding whitespace", async () => {
+    setCheckoutOrigin(`  ${validOrigin}  `);
+    const fetchMock = mockFailedCheckoutFetch();
+
+    render(<PacketCheckoutButton storeDomain="test-store.invalid" />);
+    await clickCheckout();
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(`${validOrigin}/__public-checkout`);
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+    ["malformed", "not a url"],
+    ["http", "http://cart-agent-api.onrender.com"],
+    ["credentials", "https://user:pass@cart-agent-api.onrender.com"],
+    ["query", "https://cart-agent-api.onrender.com?fallback=1"],
+    ["fragment", "https://cart-agent-api.onrender.com#checkout"],
+  ])("fails closed and does not fetch when checkout authority is %s", (_caseName, value) => {
+    setCheckoutOrigin(value);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<PacketCheckoutButton storeDomain="test-store.invalid" />);
+    fireEvent.click(screen.getByRole("button", { name: /start my fix/i }));
+
+    expect(screen.getByRole("button", { name: /start my fix/i })).toBeDisabled();
+    expect(screen.getByText(checkoutUnavailableMessage)).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps fetch failures merchant-safe without rendering a success state", async () => {
+    setCheckoutOrigin(validOrigin);
+    mockFailedCheckoutFetch();
+
+    render(<PacketCheckoutButton storeDomain="test-store.invalid" />);
+    await clickCheckout();
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Checkout could not be started. Please try again later.");
+    expect(screen.queryByText(/stripe url|backend detail|checkout session/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/app/pricing/PacketCheckoutButton.tsx
+++ b/src/app/pricing/PacketCheckoutButton.tsx
@@ -6,17 +6,48 @@ type PacketCheckoutButtonProps = {
   storeDomain: string;
 };
 
-function getCheckoutApiBase() {
-  const configured = String(process.env.NEXT_PUBLIC_SHOPIFIXER_CHECKOUT_API_BASE || "").trim();
-  if (!configured) return "https://pay.abando.ai";
-  return configured.replace(/\/$/, "");
+const checkoutUnavailableMessage = "Checkout is temporarily unavailable. Please try again later.";
+const checkoutFailedMessage = "Checkout could not be started. Please try again later.";
+
+export function resolveCheckoutApiOrigin(
+  configuredValue = process.env.NEXT_PUBLIC_SHOPIFIXER_CHECKOUT_API_BASE,
+) {
+  const configured = String(configuredValue || "").trim();
+  if (!configured) return null;
+
+  let url: URL;
+  try {
+    url = new URL(configured);
+  } catch {
+    return null;
+  }
+
+  if (
+    url.protocol !== "https:" ||
+    !url.hostname ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash
+  ) {
+    return null;
+  }
+
+  return url.origin;
 }
 
 export default function PacketCheckoutButton({ storeDomain }: PacketCheckoutButtonProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
+  const checkoutApiBase = resolveCheckoutApiOrigin();
+  const isCheckoutAvailable = Boolean(checkoutApiBase);
 
   async function handleStartMyFix() {
+    if (!checkoutApiBase) {
+      setError(checkoutUnavailableMessage);
+      return;
+    }
+
     if (!storeDomain) {
       setError("Missing store context.");
       return;
@@ -26,7 +57,7 @@ export default function PacketCheckoutButton({ storeDomain }: PacketCheckoutButt
     setIsLoading(true);
 
     try {
-      const response = await fetch(`${getCheckoutApiBase()}/__public-checkout`, {
+      const response = await fetch(`${checkoutApiBase}/__public-checkout`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -38,20 +69,19 @@ export default function PacketCheckoutButton({ storeDomain }: PacketCheckoutButt
         }),
       });
 
-      const json = await response.json().catch(() => null);
-
       if (!response.ok) {
-        throw new Error(json?.message || json?.error || json?.code || `Checkout failed (${response.status})`);
+        throw new Error(checkoutFailedMessage);
       }
 
+      const json = await response.json().catch(() => null);
       const checkoutUrl = String(json?.url || json?.checkout_url || "").trim();
       if (!checkoutUrl) {
-        throw new Error("Checkout response missing Stripe URL.");
+        throw new Error(checkoutFailedMessage);
       }
 
       window.location.assign(checkoutUrl);
     } catch (requestError) {
-      setError(requestError instanceof Error ? requestError.message : "Checkout failed.");
+      setError(requestError instanceof Error ? requestError.message : checkoutFailedMessage);
       setIsLoading(false);
     }
   }
@@ -61,12 +91,17 @@ export default function PacketCheckoutButton({ storeDomain }: PacketCheckoutButt
       <button
         type="button"
         onClick={handleStartMyFix}
-        disabled={isLoading}
+        disabled={isLoading || !isCheckoutAvailable}
+        aria-describedby={!isCheckoutAvailable ? "checkout-unavailable-message" : undefined}
         className="rounded-full bg-cyan-400 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-wait disabled:opacity-70"
       >
         {isLoading ? "Starting..." : "Start My Fix"}
       </button>
-      {error ? (
+      {!isCheckoutAvailable ? (
+        <p id="checkout-unavailable-message" className="mt-3 text-sm leading-6 text-rose-300" role="status">
+          {checkoutUnavailableMessage}
+        </p>
+      ) : error ? (
         <p className="mt-3 text-sm leading-6 text-rose-300" role="alert">
           {error}
         </p>


### PR DESCRIPTION
Mission: M004.01_REMOVE_PAY_ABANDO_PRICING_FALLBACK_AND_FAIL_CLOSED_CHECKOUT_ORIGIN

Scope:
- removes the hardcoded historical checkout fallback from the ShopiFixer pricing checkout button
- requires NEXT_PUBLIC_SHOPIFIXER_CHECKOUT_API_BASE to resolve to an explicit HTTPS origin
- rejects missing, empty, malformed, non-HTTPS, credential-bearing, query-bearing, and fragment-bearing origins
- disables checkout and shows merchant-safe unavailable copy when authority is invalid
- preserves POST /__public-checkout and existing store/plan payload semantics for valid authority

Validation:
- focused Vitest checkout-origin suite passed: 22 tests
- existing fix-status packet-authority suite passed: 23 tests
- npm run lint passed with one pre-existing type-import warning outside this slice
- commit hook passed lint, typecheck, and guard:headers
- production-equivalent build passed with NEXT_PUBLIC_SHOPIFIXER_CHECKOUT_API_BASE=https://cart-agent-api.onrender.com
- missing-variable build passed and did not substitute another checkout origin
- generated pricing artifact contains no pay.abando.ai reference

Production impact:
- no production deployment
- no Render configuration change
- no Stripe, packet, cart-agent, StaffordOS, Shopify, DNS, or pricing-content mutation

Rollback:
- revert commit 89322b1e260e05bf783c8df0cfaf53f80ad04e6d
- redeploy the prior approved Stafford Media source
- verify /pricing health and existing /fix-status packet-authority behavior

Do not merge until preview certification and later release authority are complete.